### PR TITLE
feat(apama_project): create project in current dir

### DIFF
--- a/src/apama_project/apamaProjectView.ts
+++ b/src/apama_project/apamaProjectView.ts
@@ -111,30 +111,23 @@ export class ApamaProjectView
   registerCommands(): void {
     if (this.context !== undefined) {
       this.context.subscriptions.push.apply(this.context.subscriptions, [
-        //
-        // Create project
-        //
+        
+        /** Create project */
         commands.registerCommand(
           "extension.apamaProjects.apamaToolCreateProject",
           () => {
-            //display prompt.
-            window
-              .showInputBox({
-                value: "apama_project",
-                placeHolder: "Project directory name",
-              })
-              .then((result) => {
-                if (
-                  typeof result === "string" &&
-                  workspace.rootPath !== undefined
-                ) {
-                  this.apama_project
-                    .run(workspace.rootPath, ["create", result])
-                    .catch((err: string) => {
-                      this.logger.appendLine(err);
-                    });
-                }
+            if (workspace.rootPath !== undefined) {
+                this.apama_project
+                  .run(workspace.rootPath, ["create", '.'])
+                  .then((result) => {
+                    window.showInformationMessage(result.stdout);
+                    this.logger.info(result);
+                  })
+                  .catch((err) => {
+                    window.showErrorMessage(err.stderr);
+                    this.logger.error(err);
               });
+            }
           },
         ),
 


### PR DESCRIPTION
we only want a single project per workspace directory, so we now only support creating a project within the current working directory.

this feature relies on an apama change.

we also fix the messaging, so that success & error command lines are added as information messages (in addition to being logged).