### PR TITLE
fix(apamaProjectView): remove deployment support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fixed automatic Language Server start up - if Apama is installed in a default location, or the `apamaHome` preference set to a valid location, the Language Server will automatically start up.
 * The "Create Project" command requires a minimum of 10.15.6.2.
 * A single workspace folder is now considered to hold just one project, at the top level.
+* Removed support for deploying projects. This can be manually done using the `engine_deploy` tool.
 
 # Old versions
 

--- a/package.json
+++ b/package.json
@@ -109,15 +109,6 @@
         }
       },
       {
-        "command": "extension.apamaProjects.apamaToolDeployProject",
-        "title": "Deploy Project",
-        "category": "Apama",
-        "icon": {
-          "light": "resources/light/boolean.svg",
-          "dark": "resources/dark/boolean.svg"
-        }
-      },
-      {
         "command": "extension.apamaProjects.refresh",
         "title": "Refresh",
         "category": "Apama",
@@ -207,11 +198,6 @@
         }
       ],
       "view/item/context": [
-        {
-          "when": "view == apamaProjects && viewItem == project",
-          "command": "extension.apamaProjects.apamaToolDeployProject",
-          "group": "inline@1"
-        },
         {
           "when": "view == apamaProjects && viewItem == project",
           "command": "extension.apamaProjects.apamaToolAddBundles",

--- a/src/apama_project/apamaProjectView.ts
+++ b/src/apama_project/apamaProjectView.ts
@@ -176,25 +176,6 @@ export class ApamaProjectView
         ),
 
         //
-        // Engine Deploy
-        //
-        commands.registerCommand(
-          "extension.apamaProjects.apamaToolDeployProject",
-          (project: ApamaProject) => {
-            this.apama_deploy
-              .run(project.ws.uri.fsPath, [
-                "--outputDeployDir",
-                project.label + "_deployed",
-                project.label,
-              ])
-              .then((result) =>
-                window.showInformationMessage(`${result.stdout}`),
-              )
-              .catch((err) => window.showErrorMessage(`${err}`));
-          },
-        ),
-
-        //
         // Placeholder for clicking on a bundle/project - will open files possibly or navigate to the right directory.
         //
         commands.registerCommand(


### PR DESCRIPTION
We currently don't support deployment in a sub-directory of the current project directory (ironically, this was something we deliberately axed due to bugs in that mechanism). This makes it awkward to fit deployment into the developer story when using VS Code, because ideally, the build output would be a sub-directory of the current working directory.

For now, we're removing the support for deployment. Alternatives for the future could include,

- Adding a dialog to allow the user to select the deployment directory, 
- Deploying it to a default directory outside of the workspace (i.e. `../<PROJECT_NAME>_deployed`),
- Implementing support for deployment into a subdirectory,

(Ideally, we'd go with 3), and add some mechanism to avoid recursive deployments like last time).