### PR TITLE
fix(commands): make all commands have consistent id format

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     ],
     "commands": [ 
       {
-        "command": "extension.apamaProjects.apamaToolCreateProject",
+        "command": "apama.apamaToolCreateProject",
         "title": "Create Project",
         "category": "Apama",
         "icon": {
@@ -109,7 +109,7 @@
         }
       },
       {
-        "command": "extension.apamaProjects.refresh",
+        "command": "apama.refresh",
         "title": "Refresh",
         "category": "Apama",
         "icon": {
@@ -118,7 +118,7 @@
         }
       },
       {
-        "command": "extension.apamaProjects.apamaToolAddBundles",
+        "command": "apama.apamaToolAddBundles",
         "title": "Add Bundle",
         "category": "Apama",
         "icon": {
@@ -127,7 +127,7 @@
         }
       },
       {
-        "command": "extension.apamaProjects.apamaToolRemoveBundle",
+        "command": "apama.apamaToolRemoveBundle",
         "title": "Remove Bundle",
         "category": "Apama",
         "icon": {
@@ -136,7 +136,7 @@
         }
       },
       {
-        "command": "extension.apamaProjects.close",
+        "command": "apama.close",
         "title": "Close",
         "category": "Apama",
         "icon": {
@@ -145,7 +145,7 @@
         }
       },
       {
-        "command": "extension.apamaProjects.closeGroup",
+        "command": "apama.closeGroup",
         "title": "Close Group",
         "category": "Apama",
         "icon": {
@@ -154,22 +154,22 @@
         }
       },
       {
-        "command": "extension.apama.engine_inject",
+        "command": "apama.engine_inject",
         "category": "Apama",
         "title": "correlator: engine inject"
       },
       {
-        "command": "extension.apama.engine_send",
+        "command": "apama.engine_send",
         "category": "Apama",
         "title": "correlator: engine send"
       },
       {
-        "command": "extension.apama.engine_delete",
+        "command": "apama.engine_delete",
         "category": "Apama",
         "title": "correlator: engine delete"
       },
       {
-        "command": "extension.apama.engine_watch",
+        "command": "apama.engine_watch",
         "category": "Apama",
         "title": "correlator: engine watch"
       }
@@ -178,21 +178,21 @@
       "explorer/context": [
         {
           "when": "resourceExtname == .mon",
-          "command": "extension.apama.engine_inject"
+          "command": "apama.engine_inject"
         },
         {
           "when": "resourceExtname == .evt",
-          "command": "extension.apama.engine_send"
+          "command": "apama.engine_send"
         }
       ],
       "view/title": [
         {
           "when": "view == apamaProjects",
-          "command": "extension.apamaProjects.apamaToolCreateProject",
+          "command": "apama.apamaToolCreateProject",
           "group": "navigation"
         },
         {
-          "command": "extension.apamaProjects.refresh",
+          "command": "apama.refresh",
           "when": "view == apamaProjects",
           "group": "navigation"
         }
@@ -200,12 +200,12 @@
       "view/item/context": [
         {
           "when": "view == apamaProjects && viewItem == project",
-          "command": "extension.apamaProjects.apamaToolAddBundles",
+          "command": "apama.apamaToolAddBundles",
           "group": "inline@2"
         },
         {
           "when": "view == apamaProjects && viewItem == bundle",
-          "command": "extension.apamaProjects.apamaToolRemoveBundle",
+          "command": "apama.apamaToolRemoveBundle",
           "group": "inline"
         }
       ]

--- a/src/apama_project/apamaProjectView.ts
+++ b/src/apama_project/apamaProjectView.ts
@@ -95,7 +95,7 @@ export class ApamaProjectView
         
         /** Create project */
         commands.registerCommand(
-          "extension.apamaProjects.apamaToolCreateProject",
+          "apama.apamaToolCreateProject",
           () => {
             if (workspace.rootPath !== undefined) {
                 this.apama_project
@@ -116,7 +116,7 @@ export class ApamaProjectView
         // Add Bundle
         //
         commands.registerCommand(
-          "extension.apamaProjects.apamaToolAddBundles",
+          "apama.apamaToolAddBundles",
           (project: ApamaProject) => {
             this.apama_project
               .run(project.fsDir, ["list", "bundles"])
@@ -164,7 +164,7 @@ export class ApamaProjectView
         // Remove Bundle
         //
         commands.registerCommand(
-          "extension.apamaProjects.apamaToolRemoveBundle",
+          "apama.apamaToolRemoveBundle",
           (bundle: BundleItem) => {
             this.apama_project
               .run(bundle.fsDir, ["remove", "bundle", '"' + bundle.label + '"'])
@@ -179,7 +179,7 @@ export class ApamaProjectView
         // Placeholder for clicking on a bundle/project - will open files possibly or navigate to the right directory.
         //
         commands.registerCommand(
-          "extension.apamaProjects.SelectItem",
+          "apama.SelectItem",
           (_document: TextDocument) => {
             //this.logger.appendLine(document.fileName);
             return;
@@ -189,7 +189,7 @@ export class ApamaProjectView
         //
         // refresh projects
         //
-        commands.registerCommand("extension.apamaProjects.refresh", () => {
+        commands.registerCommand("apama.refresh", () => {
           this.refresh();
         }),
       ]);

--- a/src/apama_util/commands.ts
+++ b/src/apama_util/commands.ts
@@ -43,7 +43,7 @@ export class ApamaCommandProvider {
         // engine_inject command
         //
         commands.registerCommand(
-          "extension.apama.engine_inject",
+          "apama.engine_inject",
           async (monFile) => {
             if (monFile !== undefined) {
               // Display prompt to receive port
@@ -65,7 +65,7 @@ export class ApamaCommandProvider {
         // engine_send command
         //
         commands.registerCommand(
-          "extension.apama.engine_send",
+          "apama.engine_send",
           async (evtFile?) => {
             // Display prompt to receive port
             const portInput = await window.showInputBox({
@@ -117,7 +117,7 @@ export class ApamaCommandProvider {
         //
         // engine_delete command
         //
-        commands.registerCommand("extension.apama.engine_delete", async () => {
+        commands.registerCommand("apama.engine_delete", async () => {
           // Display prompt to receive port
           const portInput = await window.showInputBox({
             value: port.toString(),


### PR DESCRIPTION
we had a variety of prefixes for our commands. there's really no need, and it makes testing it in the
future easier.