### PR TITLE
Fix the regex used for EPL identifiers to match the real IDENTIFIER grammer

### DIFF
--- a/epl.tmLanguage.json
+++ b/epl.tmLanguage.json
@@ -74,7 +74,7 @@
 		"action": {
 			"patterns": [
 				{
-					"match": "(\\s?)(action)(\\s+)([a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)(\\s?)",
+					"match": "(\\s?)(action)(\\s+)([a-zA-Z_$][a-zA-Z_$0-9]*)(\\s?)",
 					"captures": {
 						"1": {
 							"name": "text.epl"
@@ -121,7 +121,7 @@
 		"assignment": {
 			"patterns": [
 				{
-					"match": "([a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)(\\s?)(\\:=)",
+					"match": "([a-zA-Z_$][a-zA-Z_$0-9]*)(\\s?)(\\:=)",
 					"captures": {
 						"1": {
 							"name": "variable.epl"
@@ -139,7 +139,7 @@
 		"bareVariable": {
 			"patterns": [
 				{
-					"match": "\\b([a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)\\b",
+					"match": "\\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b",
 					"name": "variable.epl"
 				}
 			]
@@ -205,7 +205,7 @@
 		"event": {
 			"patterns": [
 				{
-					"match": "(\\s?)(event)(\\s+)([a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)",
+					"match": "(\\s?)(event)(\\s+)([a-zA-Z_$][a-zA-Z_$0-9]*)",
 					"captures": {
 						"1": {
 							"name": "text.epl"
@@ -246,7 +246,7 @@
 		"member": {
 			"patterns": [
 				{
-					"match": "\\b(\\.)([a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)\\b",
+					"match": "\\b(\\.)([a-zA-Z_$][a-zA-Z_$0-9]*)\\b",
 					"captures": {
 						"1": {
 							"name": "keyword.operator.epl"
@@ -261,7 +261,7 @@
 		"method": {
 			"patterns": [
 				{
-					"match": "(\\.)([a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)(\\s?)(\\()",
+					"match": "(\\.)([a-zA-Z_$][a-zA-Z_$0-9]*)(\\s?)(\\()",
 					"captures": {
 						"1": {
 							"name": "keyword.operator.epl"
@@ -282,7 +282,7 @@
 		"monitor": {
 			"patterns": [
 				{
-					"match": "(\\s?)(monitor)(\\s+)([a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)",
+					"match": "(\\s?)(monitor)(\\s+)([a-zA-Z_$][a-zA-Z_$0-9]*)",
 					"captures": {
 						"1": {
 							"name": "text.epl"
@@ -390,7 +390,7 @@
 		"using": {
 			"patterns": [
 				{
-					"match": "(using|package)(\\s+)([a-zA-Z]+[.a-zA-Z]*)(;)",
+					"match": "(using|package)(\\s+)([a-zA-Z_$][a-zA-Z_$0-9.]*)(;)",
 					"captures": {
 						"1": {
 							"name": "keyword.epl"


### PR DESCRIPTION
i.e. allow numbers, $ and _

I have NO IDEA what that weird expression they used before was thinking of.