### PR TITLE
feat: add support for relative bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## v2.1.0
-* Add support for automatically reloading the extension when the "Apama Home" configuration option is changed.
+* Added new Command Palette option `Create in Project New Folder` for easily creating a new project directory. 
+* Added support for automatically reloading the extension when the "Apama Home" configuration option is changed.
+* Added support for adding custom/non-product bundles such as the Analytics Builder Block SDK (by specifying a `bnd` file in a path relative to the project directory). 
+* Added commands to the Command Palette for adding/removing different kinds of bundles. 
+* Added the ability to add multiple product bundles at at time. 
 
 ## v2.0.0
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See also the [VSCode extension for PySys testing](https://marketplace.visualstud
 
 * Syntax highlighting
 * Error/warn messages and problems
-* Adding bundles to an Apama project
+* Adding bundles to an Apama project, including product bundles and custom bundles such as the Analytics Builder Block SDK
 * Support for debugging and launching pure single-file and multi-file EPL applications in a correlator
 
 ## Getting started
@@ -41,7 +41,7 @@ Where possible, install Apama to the default installation directory `/opt/cumulo
 
 If you want to start with an **existing Apama project** you were already working on (or clone of a sample project), simply open the folder containing the project (the folder containing the `.project` and `.dependencies` files) in your VS Code workspace. Note that at present only the first folder opened in the workspace is used as an Apama project, and that you must have the Apama project files in the top level of that folder.
 
-If you want to **create a new project**, make a directory for your project and open it in VS Code. Then open the `Apama Projects` view and click the icon near the top right to `Create Project`. You can now use that view to add any bundles required for your project (such as the Cumulocity bundle), and then use the main menu to create one or more `.mon` files for your EPL application. 
+If you want to **create a new project**, open the Command Palette and type `Apama: Create Project in New Folder` (alternatively you can create the empty folder outside of VS Code, add it to the workspace and click `Create Project` in the `Apama Projects` view). You can now use the `Apama Projects` view to add any bundles required for your project, whether product bundles (such as the Cumulocity bundle) or custom bundles (such as the Analytics Builder Block SDK). Then use the main menu to create one or more `.mon` files for your EPL application. 
 
 ## Limitations
 

--- a/package.json
+++ b/package.json
@@ -108,6 +108,15 @@
         }
       },
       {
+        "command": "apama.apamaToolCreateProjectInNewFolder",
+        "title": "Create Project in New Folder",
+        "category": "Apama",
+        "icon": {
+          "light": "resources/light/folder.svg",
+          "dark": "resources/dark/folder.svg"
+        }
+      },
+      {
         "command": "apama.refreshProjects",
         "title": "Refresh",
         "category": "Apama",

--- a/package.json
+++ b/package.json
@@ -202,10 +202,6 @@
       ],
       "commandPalette": [
         {
-          "command": "apama.apamaToolRemoveBundle",
-          "when": "false"
-        },
-        {
           "command": "apama.engine_inject",
           "when": "false"
         },

--- a/package.json
+++ b/package.json
@@ -202,14 +202,6 @@
       ],
       "commandPalette": [
         {
-          "command": "apama.apamaToolAddBundles",
-          "when": "false"
-        },
-        {
-          "command": "apama.addRelativeBundle",
-          "when": "false"
-        },
-        {
           "command": "apama.apamaToolRemoveBundle",
           "when": "false"
         },

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
         "path": "./snippets.json"
       }
     ],
-    "commands": [ 
+    "commands": [
       {
         "command": "apama.apamaToolCreateProject",
         "title": "Create Project",
@@ -124,6 +124,15 @@
         "icon": {
           "light": "resources/light/add.svg",
           "dark": "resources/dark/add.svg"
+        }
+      },
+      {
+        "command": "apama.addRelativeBundle",
+        "title": "Add Relative Bundle",
+        "category": "Apama",
+        "icon": {
+          "light": "resources/light/file.svg",
+          "dark": "resources/dark/file.svg"
         }
       },
       {
@@ -181,6 +190,11 @@
           "group": "inline@2"
         },
         {
+          "when": "view == apamaProjects && viewItem == project",
+          "command": "apama.addRelativeBundle",
+          "group": "inline@3"
+        },
+        {
           "when": "view == apamaProjects && viewItem == bundle",
           "command": "apama.apamaToolRemoveBundle",
           "group": "inline"
@@ -189,6 +203,10 @@
       "commandPalette": [
         {
           "command": "apama.apamaToolAddBundles",
+          "when": "false"
+        },
+        {
+          "command": "apama.addRelativeBundle",
           "when": "false"
         },
         {

--- a/package.json
+++ b/package.json
@@ -126,8 +126,8 @@
         }
       },
       {
-        "command": "apama.apamaToolAddBundles",
-        "title": "Add product bundle",
+        "command": "apama.bundleMenu",
+        "title": "Add bundle",
         "category": "Apama",
         "icon": {
           "light": "resources/light/add.svg",
@@ -135,13 +135,14 @@
         }
       },
       {
+        "command": "apama.apamaToolAddBundles",
+        "title": "Add product bundle",
+        "category": "Apama"
+      },
+      {
         "command": "apama.addRelativeBundle",
         "title": "Add custom bundle",
-        "category": "Apama",
-        "icon": {
-          "light": "resources/light/file.svg",
-          "dark": "resources/dark/file.svg"
-        }
+        "category": "Apama"
       },
       {
         "command": "apama.apamaToolRemoveBundle",
@@ -194,13 +195,8 @@
       "view/item/context": [
         {
           "when": "view == apamaProjects && viewItem == project",
-          "command": "apama.apamaToolAddBundles",
+          "command": "apama.bundleMenu",
           "group": "inline@2"
-        },
-        {
-          "when": "view == apamaProjects && viewItem == project",
-          "command": "apama.addRelativeBundle",
-          "group": "inline@3"
         },
         {
           "when": "view == apamaProjects && viewItem == bundle",
@@ -215,6 +211,10 @@
         },
         {
           "command": "apama.refreshProjects",
+          "when": "false"
+        },
+        {
+          "command": "apama.bundleMenu",
           "when": "false"
         }
       ]

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
       },
       {
         "command": "apama.apamaToolAddBundles",
-        "title": "Add Bundle",
+        "title": "Add product bundle",
         "category": "Apama",
         "icon": {
           "light": "resources/light/add.svg",
@@ -136,7 +136,7 @@
       },
       {
         "command": "apama.addRelativeBundle",
-        "title": "Add Relative Bundle",
+        "title": "Add custom bundle",
         "category": "Apama",
         "icon": {
           "light": "resources/light/file.svg",

--- a/src/apama_project/apamaProjectView.ts
+++ b/src/apama_project/apamaProjectView.ts
@@ -158,7 +158,7 @@ export class ApamaProjectView
           async (project?: ApamaProject) => {
             // If project is not provided (called from Command Palette), prompt user to select one
             if (!project) {
-              project = await this.promptForProject("Select a project to add a bundle to");
+              project = await this.promptForProject("Select a project to add bundles to");
               if (!project) {
                 return; // User cancelled the selection
               }
@@ -182,21 +182,25 @@ export class ApamaProjectView
                     displayList.push({ label: item });
                   }
                 });
+                // Allow multiple selections
                 return window.showQuickPick(displayList, {
-                  placeHolder: "Choose a bundle to add",
+                  placeHolder: "Choose bundles to add",
+                  canPickMany: true
                 });
               })
               .then((picked) => {
-                if (picked === undefined) {
+                if (!picked || picked.length === 0) {
                   return;
                 }
 
+                // Build command arguments with all selected bundles
+                const commandArgs = ["add", "bundle"];
+                picked.forEach(bundle => {
+                  commandArgs.push('"' + bundle.label.trim() + '"');
+                });
+
                 this.apama_project
-                  .run(project!.fsDir, [
-                    "add",
-                    "bundle",
-                    '"' + picked.label.trim() + '"',
-                  ])
+                  .run(project!.fsDir, commandArgs)
                   .then((result) => {
                     window.showInformationMessage(`${result.stdout}`);
                   })

--- a/src/apama_project/apamaProjectView.ts
+++ b/src/apama_project/apamaProjectView.ts
@@ -193,8 +193,8 @@ export class ApamaProjectView
               canSelectFiles: false,
               canSelectFolders: true,
               canSelectMany: false,
-              openLabel: "Select Parent Directory Only",
-              title: "Step 1/2: Select Parent Directory (NOT the project folder itself)"
+              openLabel: "Select Parent Directory",
+              title: "Step 1/2: Select an existing directory to use as the parent for the new project directory"
             });
             
             if (!folderUri || folderUri.length === 0) {

--- a/src/apama_project/apamaProjectView.ts
+++ b/src/apama_project/apamaProjectView.ts
@@ -188,13 +188,13 @@ export class ApamaProjectView
               apamaProjectCommand
             );
             
-            // First, use file picker to select the parent directory
+            // Then use file picker to select the parent directory only
             const folderUri = await window.showOpenDialog({
               canSelectFiles: false,
               canSelectFolders: true,
               canSelectMany: false,
-              openLabel: "Select Parent Directory",
-              title: "Select Parent Directory for New Apama Project"
+              openLabel: "Select Parent Directory Only",
+              title: "Step 1/2: Select Parent Directory (NOT the project folder itself)"
             });
             
             if (!folderUri || folderUri.length === 0) {
@@ -203,10 +203,10 @@ export class ApamaProjectView
             
             const parentDir = folderUri[0].fsPath;
             
-            // Then prompt for new folder name
+            // Then prompt for new folder name (Step 2)
             const folderName = await window.showInputBox({
-              prompt: "Enter name for the new folder",
-              placeHolder: "folder-name"
+              prompt: "Step 2/2: Enter name for the new project folder (will be created inside the parent directory)",
+              placeHolder: "project-name"
             });
             
             if (!folderName) {

--- a/src/apama_project/apamaProjectView.ts
+++ b/src/apama_project/apamaProjectView.ts
@@ -196,6 +196,18 @@ export class ApamaProjectView
           },
         ),
 
+        /** 
+         *  Add relative bundle.
+         *  This supports adding a bundle from the file system.
+         */ 
+        commands.registerCommand(
+          "apama.addRelativeBundle",
+          (project: ApamaProject) => {
+            this.logger.info("Add Relative Bundle command called");
+            return;
+          },
+        ),
+
         //
         // Remove Bundle
         //

--- a/src/apama_project/apamaProjectView.ts
+++ b/src/apama_project/apamaProjectView.ts
@@ -85,6 +85,37 @@ export class ApamaProjectView
 
   registerCommands(): void {
     if (this.context !== undefined) {
+      // Register the bundle menu command
+      this.context.subscriptions.push(
+        commands.registerCommand(
+          "apama.bundleMenu",
+          async (project?: ApamaProject) => {
+            // If project is not provided (called from Command Palette), prompt user to select one
+            if (!project) {
+              project = await this.promptForProject("Select a project to add bundles to");
+              if (!project) {
+                return; // User cancelled the selection
+              }
+            }
+
+            // Show quick pick with bundle options
+            const options = [
+              { label: "Add product bundle", command: "apama.apamaToolAddBundles" },
+              { label: "Add custom bundle", command: "apama.addRelativeBundle" }
+            ];
+
+            const selected = await window.showQuickPick(options, {
+              placeHolder: "Select bundle type to add"
+            });
+
+            if (selected) {
+              // Execute the selected command and pass the project
+              commands.executeCommand(selected.command, project);
+            }
+          }
+        )
+      );
+
       this.context.subscriptions.push.apply(this.context.subscriptions, [
         
         /** Create project in existing workspace */

--- a/src/apama_project/apamaProjectView.ts
+++ b/src/apama_project/apamaProjectView.ts
@@ -205,7 +205,7 @@ export class ApamaProjectView
             
             // Then prompt for new folder name (Step 2)
             const folderName = await window.showInputBox({
-              prompt: "Step 2/2: Enter name for the new project folder (will be created inside the parent directory)",
+              prompt: "Step 2/2: Enter name for the new Apama project folder (will be created inside the parent directory)",
               placeHolder: "project-name"
             });
             

--- a/src/apama_project/apamaProjectView.ts
+++ b/src/apama_project/apamaProjectView.ts
@@ -386,7 +386,6 @@ export class ApamaProjectView
   
   /** Initialize projects from workspaces */
   async initializeProjects(): Promise<void> {
-    this.logger.info("Initializing projects");
     // Clear existing projects
     this.projects = [];
     

--- a/src/apama_project/apamaProjectView.ts
+++ b/src/apama_project/apamaProjectView.ts
@@ -15,6 +15,7 @@ import {
   TreeItemCollapsibleState,
   TreeItem,
   WorkspaceFolder,
+  Uri,
 } from "vscode";
 import {
   ApamaProject,
@@ -227,6 +228,24 @@ export class ApamaProjectView
               .then((result) => {
                 window.showInformationMessage(result.stdout);
                 this.logger.info(result);
+                
+                const newProjectPath = path.join(parentDir, folderName);
+                window.showInformationMessage(
+                  `Project created successfully. Add to workspace?`,
+                  "Yes",
+                  "No"
+                ).then(answer => {
+                  if (answer === "Yes") {
+                    // Add the folder to workspace
+                    const uri = Uri.file(newProjectPath);
+                    workspace.updateWorkspaceFolders(
+                      workspace.workspaceFolders ? workspace.workspaceFolders.length : 0,
+                      0,
+                      { uri: uri }
+                    );
+                    this.logger.info(`Added ${newProjectPath} to workspace`);
+                  }
+                });
               })
               .catch((err) => {
                 window.showErrorMessage(err.stderr);


### PR DESCRIPTION
- Adds a new icon to the project view, that supports adding bundles from relative paths on the file system.
- Added support for running both the `addRelativeBundle`, `addBundle` and `removeBundle` from the command palette. 
- Added multi-choice for the "Add Bundle" choice, to support adding multiple bundles in one-go (saves the round trip with `apama_project`).
- Added a new command, "Create Project in New Folder", that supports running `apama_project create` in a non-existent folder.