### PR TITLE
Add Force Rebuild command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Added support for automatically reloading the extension when the "Apama Home" configuration option is changed.
 * Added support for adding custom/non-product bundles such as the Analytics Builder Block SDK (by specifying a `bnd` file in a path relative to the project directory). 
 * Added commands to the Command Palette for adding/removing different kinds of bundles. 
+* Added `Force Rebuild` to the Command Palette, which restarts the Apama language servers in case something went wrong. 
 * Added the ability to add multiple product bundles at at time. 
 
 ## v2.0.0

--- a/epl.tmLanguage.json
+++ b/epl.tmLanguage.json
@@ -1,8 +1,7 @@
 {
 	"fileTypes": [
 		"epl",
-		"mon",
-		"evt"
+		"mon"
 	],
 	"name": "apamaepl",
 	"patterns": [

--- a/package.json
+++ b/package.json
@@ -117,7 +117,16 @@
       },
       {
         "command": "apama.refreshProjects",
-        "title": "Refresh",
+        "title": "Refresh Projects View",
+        "category": "Apama",
+        "icon": {
+          "light": "resources/light/refresh.svg",
+          "dark": "resources/dark/refresh.svg"
+        }
+      },
+      {
+        "command": "apama.forceRebuild",
+        "title": "Force Rebuild",
         "category": "Apama",
         "icon": {
           "light": "resources/light/refresh.svg",

--- a/package.json
+++ b/package.json
@@ -78,8 +78,7 @@
         "id": "apamaepl",
         "extensions": [
           ".mon",
-          ".epl",
-          ".evt"
+          ".epl"
         ],
         "configuration": "./language-configuration.json"
       }

--- a/src/apama_util/commands.ts
+++ b/src/apama_util/commands.ts
@@ -9,6 +9,7 @@ import {
 import { ChildProcess, spawn } from "child_process";
 import { Writable } from "stream";
 import { Logger } from "../logger/logger";
+import { resetLanguageServers } from "../extension";
 
 export class ApamaCommandProvider {
   public constructor(
@@ -22,6 +23,16 @@ export class ApamaCommandProvider {
     if (this.context !== undefined) {
       const port: any = workspace.getConfiguration("apama").get("debugPort");
       this.context.subscriptions.push.apply(this.context.subscriptions, [
+
+
+        commands.registerCommand(
+          "apama.forceRebuild",
+          async () => {
+            await resetLanguageServers(true);
+          },
+        ),
+
+
         //
         // engine_inject command
         //


### PR DESCRIPTION
Add a "force rebuild" command to allow manually restarting the lang servers without a window reload (mostly to speed up trying out LSP changes, but might be useful for endusers especially if we have any bugs)

Also refactor the reset method to allow reusing the same logic in all cases
also call the client.dispose() method to avoid leaving any resources around