### PR TITLE
fix: default path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v2.1.1
+* Fixed a bug where the default install location for Apama was never searched.
+
 ## v2.1.0
 * Added new Command Palette option `Create in Project New Folder` for easily creating a new project directory. 
 * Added support for automatically reloading the extension when the "Apama Home" configuration option is changed.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "apama-extensions",
   "displayName": "apama-extensions",
   "description": "Support for writing Apama Streaming Analytics applications in EPL",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -108,11 +108,15 @@ export async function determineIfApamaExists(): Promise<false | string> {
 
   // See if we can find a correlator.
   const correlatorResolver = new ExecutableResolver("correlator", logger);
+  let correlatorResolve;
+  
+  if (userApamaHome != undefined && userApamaHome != "") {
+    // If the user has specified an Apama Home, we only use that.
+    correlatorResolve = await correlatorResolver.resolve(path.join(userApamaHome as string, "bin"));
+  } else {
+    correlatorResolve = await correlatorResolver.resolve();
+  }
 
-  // If the user has specified an Apama Home, we only use that.
-  const correlatorResolve = await correlatorResolver.resolve(
-    path.join(userApamaHome as string, "bin"),
-  );
 
   if (correlatorResolve.isOk()) {
     logger.debug(`Found the correlator at ${correlatorResolve.value}`);

--- a/src/settings/ExecutableResolver.ts
+++ b/src/settings/ExecutableResolver.ts
@@ -37,11 +37,6 @@ export class ExecutableResolver {
       );
     }
 
-    const pathResolved = await this.findInPath();
-    if (pathResolved.isOk()) {
-      return pathResolved; // Return the Result directly, don't wrap it in another ok()
-    }
-
     return await this.findInCommonLocations();
   }
 


### PR DESCRIPTION
couple of things are broken here,

- we never checked common locations because the default apamaHome value went from null to "", and we removed the undefined check anyway.
- our find in path check is broken on 26.x because our executables are at /usr/bin.