### PR TITLE
feat(apamaProject): remove support for .project files nested deeply in workspace folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## v2.2.0
-* The Apama Project view now only searches the top level directory in each workspace folder for projects. It no longer searches for projects nested under the top level workspace folder.
+* The "Apama Projects" view now only searches the top level directory in each workspace folder for projects. It no longer searches for projects nested under the top level workspace folder.
 
 ## v2.1.1
 * Fixed a bug where the default install location for Apama was never searched.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v2.2.0
+* The Apama Project view now only searches the top level directory in each workspace folder for projects. It no longer searches for projects nested under the top level workspace folder.
+
 ## v2.1.1
 * Fixed a bug where the default install location for Apama was never searched.
 

--- a/src/apama_project/apamaProject.ts
+++ b/src/apama_project/apamaProject.ts
@@ -37,7 +37,7 @@ export class ApamaProject extends TreeItem implements ApamaTreeItem {
   instance = false;
 
   /**
-   * See if the given workspace is a project.
+   * See if the given folder is a project.
    * @param logger 
    * @param ws 
    * @param apama_project 

--- a/src/apama_project/apamaProject.ts
+++ b/src/apama_project/apamaProject.ts
@@ -3,7 +3,6 @@ import {
   TreeItemCollapsibleState,
   WorkspaceFolder,
   Uri,
-  RelativePattern,
   workspace,
 } from "vscode";
 import * as path from "path";
@@ -37,45 +36,47 @@ export class ApamaProject extends TreeItem implements ApamaTreeItem {
   contextValue = "project";
   instance = false;
 
-  //
-  // Find all the projects in a workspace
-  //
+  /**
+   * See if the given workspace is a project.
+   * @param logger 
+   * @param ws 
+   * @param apama_project 
+   * @param resourceDir 
+   * @returns 
+   */
   static async scanProjects(
     logger: Logger,
     ws: WorkspaceFolder,
     apama_project: ApamaRunner,
     resourceDir: string
-  ): Promise<ApamaProject[]> {
-    const result: ApamaProject[] = [];
+  ): Promise<ApamaProject | undefined> {
+    // Check if .dependencies file exists directly in the root of the given workspace folder
+    const dependenciesPath = Uri.joinPath(ws.uri, ".dependencies");
 
-    //find .projects, but exclude anything with _deployed suffix
-    //also covers all roots of a multi root workspace
-    const projectsPattern: RelativePattern = new RelativePattern(
-      ws,
-      "**/.project",
-    );
-    const ignorePattern: RelativePattern = new RelativePattern(
-      ws,
-      "**/*_deployed/**",
-    );
-    const projectNames = await workspace.findFiles(
-      projectsPattern,
-      ignorePattern,
-    );
+    try {
+      await workspace.fs.stat(dependenciesPath); // Check if .dependencies exists in the root
+      logger.info(
+        `Found Apama project (.dependencies) in root of: ${ws.uri.fsPath}`,
+      );
 
-    for (let index = 0; index < projectNames.length; index++) {
-      const project: Uri = projectNames[index];
-      const current: ApamaProject = new ApamaProject(
+      // If stat succeeds, the file exists - create the project object for this workspace folder
+      const project = new ApamaProject(
         logger,
-        path.basename(path.dirname(project.fsPath)),
-        path.dirname(project.fsPath),
+        ws.name, // Use workspace folder name as project label
+        ws.uri.fsPath, // Use workspace folder path as project directory
         ws,
         apama_project,
         resourceDir,
       );
-      result.push(current);
+      return project; // Return the single project for this workspace
+
+    } catch {
+      // If stat fails (e.g., file not found), this workspace folder is not an Apama project root
+      logger.info(
+        `No .dependencies file found in root of ${ws.uri.fsPath}. Not treating as Apama project.`,
+      );
+      return undefined; // Return undefined, indicating no project found for this workspace
     }
-    return result;
   }
 
   //

--- a/src/apama_project/apamaProject.ts
+++ b/src/apama_project/apamaProject.ts
@@ -72,7 +72,7 @@ export class ApamaProject extends TreeItem implements ApamaTreeItem {
 
     } catch {
       // If stat fails (e.g., file not found), this workspace folder is not an Apama project root
-      logger.info(
+      logger.debug(
         `No .dependencies file found in root of ${ws.uri.fsPath}. Not treating as Apama project.`,
       );
       return undefined; // Return undefined, indicating no project found for this workspace

--- a/src/apama_project/apamaProjectView.ts
+++ b/src/apama_project/apamaProjectView.ts
@@ -61,7 +61,7 @@ export class ApamaProjectView
     // Watch for changes to the `.dependencies` file, to refresh our project view.
     // Now, we are checking for all dependencies files: this is because we need to check /all/ open folders in the workspace, 
     // even if we only care about the root folder.
-    // The other alternative is to create seperate listeners for each workspace, where each listener would only
+    // The other alternative is to create seperate listeners for each workspace folder, where each listener would only
     // check the root `.dependencies` file, which feels like far too much effort.
     this.fsWatcher = workspace.createFileSystemWatcher("**/*.dependencies");
 

--- a/src/apama_project/apamaProjectView.ts
+++ b/src/apama_project/apamaProjectView.ts
@@ -64,12 +64,11 @@ export class ApamaProjectView
     // The other alternative is to create seperate listeners for each workspace, where each listener would only
     // check the root `.dependencies` file, which feels like far too much effort.
     this.fsWatcher = workspace.createFileSystemWatcher("**/*.dependencies");
-    this.delWatcher = workspace.createFileSystemWatcher("**/*.dependencies"); 
 
     this.fsWatcher.onDidCreate((_item) => {
       this.refresh();
     });
-    this.delWatcher.onDidDelete(() => {
+    this.fsWatcher.onDidDelete(() => {
       this.refresh();
     });
     this.fsWatcher.onDidChange((_item) => {

--- a/src/apama_project/apamaProjectView.ts
+++ b/src/apama_project/apamaProjectView.ts
@@ -44,7 +44,6 @@ export class ApamaProjectView
   private treeView: TreeView<{}>;
 
   private fsWatcher: FileSystemWatcher;
-  private delWatcher: FileSystemWatcher;
   //
   // Added facilities for multiple workspaces - this will hopefully allow
   // ssh remote etc to work better later on, plus allows some extra organisational
@@ -91,7 +90,6 @@ export class ApamaProjectView
    */
   dispose(): void {
     this.fsWatcher.dispose();
-    this.delWatcher.dispose();
   }
 
   registerCommands(): void {

--- a/src/apama_project/apamaProjectView.ts
+++ b/src/apama_project/apamaProjectView.ts
@@ -59,8 +59,10 @@ export class ApamaProjectView
     this.registerCommands();
 
     // Watch for changes to the `.dependencies` file, to refresh our project view.
-    // Now, we are checking for all dependencies files: this is because we need to check /all/ open workspaces.
-    // The other alternative is to create seperate listeners for each workspace, which feels like far too much effort.
+    // Now, we are checking for all dependencies files: this is because we need to check /all/ open folders in the workspace, 
+    // even if we only care about the root folder.
+    // The other alternative is to create seperate listeners for each workspace, where each listener would only
+    // check the root `.dependencies` file, which feels like far too much effort.
     this.fsWatcher = workspace.createFileSystemWatcher("**/*.dependencies");
     this.delWatcher = workspace.createFileSystemWatcher("**/*.dependencies"); 
 

--- a/src/apama_project/apamaProjectView.ts
+++ b/src/apama_project/apamaProjectView.ts
@@ -8,7 +8,7 @@ import {
   EventEmitter,
   Event,
   TreeView,
-  FileSystemWatcher,
+  FileSystemWatcher, RelativePattern,
   ExtensionContext,
   QuickPickItem,
   TextDocument,
@@ -43,8 +43,7 @@ export class ApamaProjectView
   // eslint-disable-next-line
   private treeView: TreeView<{}>;
 
-  private fsWatcher: FileSystemWatcher;
-  private delWatcher: FileSystemWatcher;
+  private watchers: Map<string, FileSystemWatcher> = new Map(); // Map workspace URI to watcher
   //
   // Added facilities for multiple workspaces - this will hopefully allow
   // ssh remote etc to work better later on, plus allows some extra organisational
@@ -58,30 +57,75 @@ export class ApamaProjectView
     //project commands
     this.registerCommands();
 
-    //this file is created/updated/deleted as projects come and go and depends on the "current" set of file systems
-    this.fsWatcher = workspace.createFileSystemWatcher("**/*.dependencies");
-    //but for deletions of the entire space we need
-    this.delWatcher = workspace.createFileSystemWatcher("**/*"); //if you delete a directory it will not trigger all contents
-    //handlers
-    this.fsWatcher.onDidCreate((_item) => {
-      this.refresh();
-    });
-    this.delWatcher.onDidDelete(() => {
-      this.refresh();
-    });
-    this.fsWatcher.onDidChange((_item) => {
-      this.refresh();
-    });
+    // Set up watchers for existing workspace folders and listen for changes
+    this.updateWatchers();
     
     // Listen for workspace folder changes (added or removed folders)
-    workspace.onDidChangeWorkspaceFolders(() => {
-      this.refresh();
-    });
+    workspace.onDidChangeWorkspaceFolders(() => this.updateWatchers());
 
     //the component
     this.treeView = window.createTreeView("apamaProjects", {
       treeDataProvider: this,
     });
+  }
+  /**
+   * Dispose of resources used by the view (specifically file watchers).
+   */
+  dispose(): void {
+    this.watchers.forEach(watcher => watcher.dispose());
+    this.watchers.clear();
+    this.logger.info("Disposed ApamaProjectView file watchers.");
+  }
+
+  /**
+   * Creates, updates, and removes file watchers based on the current workspace folders.
+   * Ensures watchers only monitor the root `.dependencies` file for each folder.
+   */
+  private updateWatchers(): void {
+    const currentFolders = new Set<string>();
+    (workspace.workspaceFolders || []).forEach(folder => currentFolders.add(folder.uri.toString()));
+
+    // Remove watchers for folders that no longer exist
+    this.watchers.forEach((watcher, uri) => {
+      if (!currentFolders.has(uri)) {
+        this.logger.info(`Disposing watcher for removed folder: ${uri}`);
+        watcher.dispose();
+        this.watchers.delete(uri);
+      }
+    });
+
+    // Add watchers for new folders
+    (workspace.workspaceFolders || []).forEach(folder => {
+      const uriString = folder.uri.toString();
+      if (!this.watchers.has(uriString)) {
+        this.logger.info(`Creating watcher for folder: ${uriString}`);
+        // Watch only the .dependencies file at the root of this specific folder
+        const watcher = workspace.createFileSystemWatcher(
+          new RelativePattern(folder, ".dependencies")
+        );
+
+        // Trigger refresh on create, change, or delete of the root .dependencies file
+        watcher.onDidCreate(() => {
+          this.logger.info(`.dependencies created in ${uriString}, refreshing projects.`);
+          this.refresh();
+        });
+        watcher.onDidChange(() => {
+          this.logger.info(`.dependencies changed in ${uriString}, refreshing projects.`);
+          this.refresh();
+        });
+        watcher.onDidDelete(() => {
+          this.logger.info(`.dependencies deleted from ${uriString}, refreshing projects.`);
+          this.refresh();
+        });
+
+        this.watchers.set(uriString, watcher);
+        // Note: We might need to add watcher to context.subscriptions if managing disposal there,
+        // but manual disposal in updateWatchers and dispose() is also fine.
+      }
+    });
+
+    // Initial refresh after updating watchers
+    this.refresh();
   }
 
   registerCommands(): void {
@@ -533,14 +577,18 @@ export class ApamaProjectView
     
     // Scan for projects in each workspace
     for (const ws of workspaceFolders) {
-      const workspaceProjects = await ApamaProject.scanProjects(
+      // Check this workspace folder for a project at its root
+      const project = await ApamaProject.scanProjects(
         this.logger,
         ws,
         apama_project,
         this.context.asAbsolutePath("resources")
       );
 
-      this.projects.push(...workspaceProjects);
+      // If a project was found (not undefined), add it to the list
+      if (project) {
+        this.projects.push(project);
+      }
     }
   }
 


### PR DESCRIPTION
we forgot to remove support for projects in nested folders (not top-level), which means it spends a loooong time searching for projects in a big tree, and the Apama projects view gets very cluttered