### PR TITLE
feat: `getCommand` returns an array

### DIFF
--- a/src/apama_debug/correlatorDebugSession.ts
+++ b/src/apama_debug/correlatorDebugSession.ts
@@ -19,6 +19,7 @@ import { basename } from "path";
 import * as vscode from "vscode";
 import {
   ApamaExecutables,
+  getCommandAsInterface,
   getCommandLine,
 } from "../apama_util/apamaenvironment";
 import { ApamaRunner } from "../apama_util/apamarunner";
@@ -94,7 +95,7 @@ export class CorrelatorDebugSession extends DebugSession {
   }
 
   private async runCorrelator(extraargs: string[]): Promise<vscode.Task | false> {
-    const corrCmd = await getCommandLine(ApamaExecutables.CORRELATOR);
+    const corrCmd = await getCommandAsInterface(ApamaExecutables.CORRELATOR);
     if (!corrCmd) {return false;}
     let localargs: string[] = this.config.args.concat([
       "-p",
@@ -110,8 +111,8 @@ export class CorrelatorDebugSession extends DebugSession {
       "DebugCorrelator",
       "correlator",
       new vscode.ShellExecution(
-        corrCmd,
-        localargs,
+        corrCmd.command,
+        corrCmd.args
       ),
       [],
     );
@@ -447,7 +448,7 @@ export class CorrelatorDebugSession extends DebugSession {
       this.logger.info("Stop requested to port " + this.config.port.toString());
       const managerExe = await getCommandLine(ApamaExecutables.MANAGEMENT);
       if (!managerExe) {return;}
-      const manager = new ApamaRunner(ApamaExecutables.MANAGEMENT, ApamaExecutables.MANAGEMENT);
+      const manager = new ApamaRunner(ApamaExecutables.MANAGEMENT, managerExe);
       manager.run(".", [
         "-s",
         "debug_stop",

--- a/src/apama_debug/correlatorDebugSession.ts
+++ b/src/apama_debug/correlatorDebugSession.ts
@@ -112,7 +112,7 @@ export class CorrelatorDebugSession extends DebugSession {
       "correlator",
       new vscode.ShellExecution(
         corrCmd.command,
-        corrCmd.args
+        [...corrCmd.args, ...localargs]
       ),
       [],
     );

--- a/src/apama_util/apamaenvironment.ts
+++ b/src/apama_util/apamaenvironment.ts
@@ -54,11 +54,7 @@ async function getApamaExecutableCommand(command: ApamaExecutables, showError=tr
 export async function getCommandLine(command: ApamaExecutables, showError=true) {
   const apama_executable_command = await getApamaExecutableCommand(command, showError);
   if (apama_executable_command.isOk()) {
-    let command = `${apama_executable_command.value.command}`
-    // We do this rather than `args.join(" ")`, because then we don't introduce any 
-    // odd spaces. Also, I imagine this is optimized out at some level of the interpreter.
-    apama_executable_command.value.args.forEach((x) => command = command + x);
-    return command;
+    return [apama_executable_command.value.command, ...apama_executable_command.value.args];
   }
   return false;
 }

--- a/src/apama_util/apamarunner.ts
+++ b/src/apama_util/apamarunner.ts
@@ -12,13 +12,13 @@ export class ApamaRunner {
 
   constructor(
     public name: string,
-    public command: string,
+    public command: string[],
   ) {}
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async run(workingDir: string, args: string[]): Promise<any> {
     //if fails returns promise.reject including err
-    return await exec(this.command + " " + args.join(" "), { cwd: workingDir });
+    return await exec(this.command.join(" ") + " " + args.join(" "), { cwd: workingDir });
   }
 }
 

--- a/src/apama_util/apamataskprovider.ts
+++ b/src/apama_util/apamataskprovider.ts
@@ -42,7 +42,7 @@ export class ApamaTaskProvider implements TaskProvider {
       scope,
       task + "-" + port,
       "apama",
-      new ShellExecution(executable.command, [...executable.args, " -p", port]),
+      new ShellExecution(executable.command, [...executable.args, "-p", port]),
       [],
     );
     return finalTask;

--- a/src/apama_util/apamataskprovider.ts
+++ b/src/apama_util/apamataskprovider.ts
@@ -7,7 +7,7 @@ import {
   TaskGroup,
   TaskScope,
 } from "vscode";
-import { ApamaExecutables, getCommandLine } from "./apamaenvironment";
+import { ApamaExecutables, getCommandAsInterface } from "./apamaenvironment";
 import { Logger } from "../logger/logger";
 export class ApamaTaskProvider implements TaskProvider {
   constructor(
@@ -32,7 +32,9 @@ export class ApamaTaskProvider implements TaskProvider {
     }
 
     // Substitute the executable with the current known Apama executable.
-    const executable = await getCommandLine(cmdline);
+    const executable = await getCommandAsInterface(cmdline);
+
+    if (!executable) { return; }
 
     this.logger.appendLine("Running on port " + port);
     const finalTask = new Task(
@@ -40,7 +42,7 @@ export class ApamaTaskProvider implements TaskProvider {
       scope,
       task + "-" + port,
       "apama",
-      new ShellExecution(executable + [" -p", port].join(" ")),
+      new ShellExecution(executable.command, [...executable.args, " -p", port]),
       [],
     );
     return finalTask;


### PR DESCRIPTION
it's a potential issue to pass around strings, as opposed to passing around arrays. 