### PR TITLE
Clarify mac readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ limactl create --name debian template://debian-12
 limactl create --name debian-x86 --arch x86_64 --rosetta template://debian-12
 ```
 
-Once you virtual machine has been created, start it up, and shell into it. Then install Apama using the instructions from "Using a Linux installation".
+Once your virtual machine is created, start it up, and shell into it. Then install Apama using the instructions from "Using a Linux installation".
 
 Use the [Visual Studio Code Remote Development Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) to connect to your virtual machine.
 

--- a/README.md
+++ b/README.md
@@ -70,11 +70,29 @@ The versions of Apama and the SDKs can be configured: see the DevContainer READM
 To use DevContainers, you will need a containerization environment on your computer. [Microsoft's VS Code documentation](https://code.visualstudio.com/remote/advancedcontainers/docker-options) should give you some guidance in that area.
 
 ### Using the extension on macOS
-For users on macOS (Intel or Apple Silicon), we recommend using the [colima](https://github.com/abiosoft/colima) container runtime. 
+#### Using Lima to create a virtual machine
+For users on macOS (Intel or Apple Silicon), we recommend using the [lima](https://github.com/lima-vm/lima) virtualization runtime. 
 
-Once the container runtime is installed, you should create a container with Debian as the base image. Then install Apama into the container as described in "Using a Linux installation" above. If using Apama 26.x, use Debian version 12, on native ARM64. For Apama 10.15 you need to use x86. 
+Once Lima has been installed, create a virtual machine with Debian as the image. If you are on 26.x and on an Apple Silicon machine, create an ARM64 VM. Otherwise, create an x86 VM.
 
-Use the [Visual Studio Code Remote Development Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) to connect to your Dev Container. 
+```bash
+# ARM64
+limactl create --name debian template://debian-12
+
+# x86
+limactl create --name debian-x86 --arch x86_64 --rosetta template://debian-12
+```
+
+Once you virtual machine has been created, start it up, and shell into it. Then install Apama using the instructions from "Using a Linux installation".
+
+Use the [Visual Studio Code Remote Development Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) to connect to your virtual machine.
+
+Tip: to show your Lima VMs in Remote-SSH, run `echo -e "\nInclude ${LIMA_HOME:-$HOME/.lima}/debian-x86/ssh.config" >> ~/.ssh/config` in a terminal ([source](https://github.com/lima-vm/lima/discussions/1890)).
+
+#### Dev Container
+Another possible approach is to use [colima](https://github.com/abiosoft/colima) and the Dev Container approach mentioned in "Using a Development Container".
+
+This is currently an x86 image.
 
 ### Opening your first Apama project
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For the older 10.15 release:
 
 For Apama 26.x and higher there is no Windows installation package of Apama, so we recommend using the VS Code [WSL](https://code.visualstudio.com/docs/remote/wsl) extension which allows VS Code running on Windows to use a Linux-based Apama installation package. 
 
-1. Install the latest version of [WSL](https://learn.microsoft.com/en-us/windows/wsl/install), using the **Debian** distribution of Linux. This may take some time and often requires a restart. See the WSL and also VS Code instructions for full details, but typical steps on a recent version of Windows would be:
+1. Install the latest version of [WSL](https://learn.microsoft.com/en-us/windows/wsl/install), and add the **Debian** distribution of Linux. This may take some time and often requires a restart. See the WSL and also VS Code instructions for full details, but typical steps on a recent version of Windows would be:
     * Open a PowerShell terminal "as Administrator"
     * `wsl --install`
     * `wsl --install -d Debian`
@@ -70,9 +70,11 @@ The versions of Apama and the SDKs can be configured: see the DevContainer READM
 To use DevContainers, you will need a containerization environment on your computer. [Microsoft's VS Code documentation](https://code.visualstudio.com/remote/advancedcontainers/docker-options) should give you some guidance in that area.
 
 ### Using the extension on macOS
-For users on macOS (Intel or Apple Silicon), we recommend using [colima](https://github.com/abiosoft/colima) and the DevContainer approach mentioned above.
+For users on macOS (Intel or Apple Silicon), we recommend using the [colima](https://github.com/abiosoft/colima) container runtime. 
 
-This is currently an x86 image.
+Once the container runtime is installed, you should create a container with Debian as the base image. Then install Apama into the container as described in "Using a Linux installation" above. If using Apama 26.x, use Debian version 12, on native ARM64. For Apama 10.15 you need to use x86. 
+
+Use the [Visual Studio Code Remote Development Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) to connect to your Dev Container. 
 
 ### Opening your first Apama project
 


### PR DESCRIPTION
Trying to clarify that for Apama 26.x you can now use the new native ARM64 packages but have to use x86 on 10.15 or if you want to use Apama docker images. 

