### PR TITLE
Windows fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## v2.2.1
-* Fixed an issue with the extension not locating the Apama installation when executed in a Docker development container. 
+* Fixed an issue with the extension not locating the Apama installation when executed in a Docker development container, and on Windows. 
 
 ## v2.2.0
 * The "Apama Projects" view now only searches the top level directory in each workspace folder for projects. It no longer searches for projects nested under the top level workspace folder.

--- a/src/apama_project/apamaProjectView.ts
+++ b/src/apama_project/apamaProjectView.ts
@@ -282,6 +282,7 @@ export class ApamaProjectView
               }
             }
 
+            // nb: in future we might use the --json output mode added instead of parsing the text output
             apama_project
               .run(project.fsDir, ["list", "bundles"])
               .then((result) => {

--- a/src/apama_util/apamaenvironment.ts
+++ b/src/apama_util/apamaenvironment.ts
@@ -41,7 +41,7 @@ async function getApamaExecutableCommand(command: ApamaExecutables, showError=tr
         return ok({command: `${apamaBin}/${command}`, args: []})
       }
     } else {
-      return ok({command: `${apamaBin}/apama_env.bat`, args: [command]});
+      return ok({command: `${apamaBin}\\apama_env.bat`, args: [command]});
     }
   }
 

--- a/src/apama_util/apamarunner.ts
+++ b/src/apama_util/apamarunner.ts
@@ -2,6 +2,10 @@ import { exec, execFile} from "child_process";
 import { platform } from "os";
 import { promisify } from "util";
 import { logger } from "../extension";
+import {
+  ProgressLocation,
+  window
+} from "vscode";
 
 const execPromisify = promisify(exec);
 const execFilePromisify = promisify(execFile);
@@ -20,29 +24,35 @@ export class ApamaRunner {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async run(workingDir: string, args: string[]): Promise<any> {
-    try {
-      //if fails returns promise.reject including err
-      if (platform() === "win32") {
-        logger.debug("Running command: " + this.command[0] + " " + [...this.command.slice(1), ...args].join(" "));
-        // Not ideal: exec is not so secure, but execFile doesn't work with .bat file and spawn hangs mysteriously (even with stdio ignore),
-        // so given Windows isn't a main platform going forward and that there isn't a real way this could be used to escalate privilieges, this will do for now
-        return await execPromisify([...this.command, ...args].join(" "), { cwd: workingDir });
-      } else {
-        return await execFilePromisify(
-          this.command[0],
-          [...this.command.slice(1), ...args],
-          { cwd: workingDir }
-        );
+    return await window.withProgress(
+      {
+        // since sometimes (e.g. apama_project) the command takes a long time, giving a progress notification is helpful
+        location: ProgressLocation.Notification,
+        title: `Running ${this.name}...`,
+        cancellable: false,
+      },
+      async () => 
+      {
+        try {
+          if (platform() === "win32") {
+            logger.debug("Running command: " + this.command[0] + " " + [...this.command.slice(1), ...args].join(" "));
+            return await execPromisify([...this.command, ...args].join(" "), { cwd: workingDir });
+          } else {
+            return await execFilePromisify(
+              this.command[0],
+              [...this.command.slice(1), ...args],
+              { cwd: workingDir }
+            );
+          }
+        } catch (error) {
+          const enhancedError = new Error(
+            `Error running command '${this.command[0]} ${[...this.command.slice(1), ...args].join(" ")}': ${error}`
+          );
+          if (error instanceof Error) enhancedError.stack = error.stack;
+          throw enhancedError;
+        }
       }
-    } catch (error) {
-      const enhancedError = new Error(
-        `Error running command '${this.command[0]} ${[...this.command.slice(1), ...args].join(" ")}': ${error}`
-      );
-      if (error instanceof Error) {
-        enhancedError.stack = error.stack;
-      }
-      throw enhancedError;
-    }
+    );
   }
 }
 

--- a/src/apama_util/apamarunner.ts
+++ b/src/apama_util/apamarunner.ts
@@ -1,11 +1,11 @@
-import { ChildProcess, spawn as spawnCallback, execFile as execFileCallback} from "child_process";
-import { Logger } from "../logger/logger";
+import { exec, execFile} from "child_process";
 import { platform } from "os";
 import { promisify } from "util";
 import { logger } from "../extension";
 
-const spawn = promisify(spawnCallback);
-const execFile = promisify(execFileCallback);
+const execPromisify = promisify(exec);
+const execFilePromisify = promisify(execFile);
+
 
 export class ApamaRunner {
   stdout = "";
@@ -20,104 +20,29 @@ export class ApamaRunner {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async run(workingDir: string, args: string[]): Promise<any> {
-    //if fails returns promise.reject including err
-    if (platform() === "win32") {
-      logger.info("Running command: " + this.command[0] + " " +  [...this.command.slice(1), ...args].join(" "));
-      return await spawn(
-        this.command[0],
-        [...this.command.slice(1), ...args],
-        {cwd: workingDir, shell:true, 
-        // do not pipe stdin
-        stdio: ["ignore", "pipe", "pipe"]
-        }
-      )
-    } else {
-      return await execFile(
-        this.command[0],
-        [...this.command.slice(1), ...args],
-        {cwd: workingDir}
-      )
-    }
-  }
-}
-
-export class ApamaAsyncRunner {
-  stdout = "";
-  stderr = "";
-  child?: ChildProcess;
-
-  constructor(
-    public name: string,
-    public command: string,
-    private logger: Logger,
-  ) {}
-
-  //
-  // If you call this withShell = true it will run the command under that shell
-  // this means the process may need to be managed separately as it may get detached
-  // when you kill the parent (correlator behaves that way)
-  // I use engine_management to control the running correlator
-  //
-  // TODO: pipes configuration might be worth passing as an argument
-  //
-  public start(
-    args: string[],
-    withShell: boolean,
-    defaultHandlers: boolean,
-  ): ChildProcess {
-    //N.B. this potentially will leave the correlator running - future work required...
-    if (this.child && !this.child.killed) {
-      this.logger.appendLine(this.name + " already started, stopping...");
-      this.child.kill("SIGKILL");
-    }
-
-    this.logger.appendLine("Starting " + this.name);
-    this.child = spawnCallback(this.command[0], [...this.command.slice(1), ...args], {
-      shell: withShell,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-
-    //Running with process Id
-    this.logger.appendLine(this.name + " started, PID:" + this.child.pid);
-
-    //Notify the logger if it stopped....
-    this.child.once("exit", (exitCode) =>
-      this.logger.appendLine(this.name + " stopped, exit code: " + exitCode),
-    );
-
-    if (defaultHandlers) {
-      this.child.stdout?.setEncoding("utf8");
-      this.child.stdout?.on("data", (data: string) => {
-        if (this.logger) {
-          this.logger.appendLine(data);
-        }
-      });
-    }
-
-    return this.child;
-  }
-
-  public stop(): Promise<void> {
-    return new Promise((resolve) => {
-      if (this.child && !this.child.killed) {
-        this.child.once("exit", () => {
-          resolve();
-        });
-
-        this.logger.appendLine("Process " + this.name + " stopping...");
-        this.child.kill("SIGINT");
-        const attemptedToKill = this.child;
-        setTimeout(() => {
-          if (!attemptedToKill.killed) {
-            this.logger.appendLine(
-              "Failed to stop shell in 5 seconds, killing...",
-            );
-            attemptedToKill.kill("SIGKILL");
-          }
-        }, 5000);
+    try {
+      //if fails returns promise.reject including err
+      if (platform() === "win32") {
+        logger.debug("Running command: " + this.command[0] + " " + [...this.command.slice(1), ...args].join(" "));
+        // Not ideal: exec is not so secure, but execFile doesn't work with .bat file and spawn hangs mysteriously (even with stdio ignore),
+        // so given Windows isn't a main platform going forward and that there isn't a real way this could be used to escalate privilieges, this will do for now
+        return await execPromisify([...this.command, ...args].join(" "), { cwd: workingDir });
       } else {
-        resolve();
+        return await execFilePromisify(
+          this.command[0],
+          [...this.command.slice(1), ...args],
+          { cwd: workingDir }
+        );
       }
-    });
+    } catch (error) {
+      const enhancedError = new Error(
+        `Error running command '${this.command[0]} ${[...this.command.slice(1), ...args].join(" ")}': ${error}`
+      );
+      if (error instanceof Error) {
+        enhancedError.stack = error.stack;
+      }
+      throw enhancedError;
+    }
   }
 }
+

--- a/src/apama_util/apamarunner.ts
+++ b/src/apama_util/apamarunner.ts
@@ -2,6 +2,7 @@ import { ChildProcess, spawn as spawnCallback, execFile as execFileCallback} fro
 import { Logger } from "../logger/logger";
 import { platform } from "os";
 import { promisify } from "util";
+import { logger } from "../extension";
 
 const spawn = promisify(spawnCallback);
 const execFile = promisify(execFileCallback);
@@ -11,7 +12,9 @@ export class ApamaRunner {
   stderr = "";
 
   constructor(
+    /** Display name for this process */
     public name: string,
+    /** e.g. [XXX/apama_env, apama_project] or [XXX/apama_project] */
     public command: string[],
   ) {}
 
@@ -19,10 +22,14 @@ export class ApamaRunner {
   async run(workingDir: string, args: string[]): Promise<any> {
     //if fails returns promise.reject including err
     if (platform() === "win32") {
+      logger.info("Running command: " + this.command[0] + " " +  [...this.command.slice(1), ...args].join(" "));
       return await spawn(
         this.command[0],
-        [...args.slice(1), ...args],
-        {cwd: workingDir}
+        [...this.command.slice(1), ...args],
+        {cwd: workingDir, shell:true, 
+        // do not pipe stdin
+        stdio: ["ignore", "pipe", "pipe"]
+        }
       )
     } else {
       return await execFile(


### PR DESCRIPTION
Wrong args passed, must pass shell=true due to recent security fix

Backed out the use of secure spawn() call on Windows since I couldn't make it do anything but hang (even with shell=True and stdio=[ignore,pipe,pipe]) and the main thing is for the linux use to be as good as it can be

Also added a progress notificiation while running commands since apama_project takes so long